### PR TITLE
✨ feature: Menu Item Input Gesture Improvements

### DIFF
--- a/TJC.GUI/GlobalUsings.cs
+++ b/TJC.GUI/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using Avalonia.Controls;
+global using Avalonia.Input;
 global using ReactiveUI;
 global using TJC.AssemblyExtensions.Attributes;
 global using TJC.GUI.Menu.Base;

--- a/TJC.GUI/Menu/Base/MenuItemBase.cs
+++ b/TJC.GUI/Menu/Base/MenuItemBase.cs
@@ -10,6 +10,8 @@ public abstract class MenuItemBase(MenuItemSettings settings) : IMenuItem
 {
     public abstract string Header { get; }
 
+    public virtual KeyGesture? DefaultGesture => null;
+
     #region Create
 
     public MenuItem? CreateMenuItem()

--- a/TJC.GUI/Menu/Base/MenuItemBase.cs
+++ b/TJC.GUI/Menu/Base/MenuItemBase.cs
@@ -45,13 +45,12 @@ public abstract class MenuItemBase(MenuItemSettings settings) : IMenuItem
     {
         var subMenuItems = GetSubMenuItems().CreateMenuItems();
         var header = settings.Header ?? Header;
-        if (settings.Gesture != null)
-            header += $" ({settings.Gesture})";
         var menuItem = new MenuItem
         {
-            Header = header,
-            Command = CreateCommand(),
-            ItemsSource = subMenuItems
+            Header       = header,
+            Command      = CreateCommand(),
+            ItemsSource  = subMenuItems,
+            InputGesture = settings.Gesture ?? DefaultGesture
         };
         return menuItem;
     }

--- a/TJC.GUI/Menu/Base/MenuItemBase.cs
+++ b/TJC.GUI/Menu/Base/MenuItemBase.cs
@@ -43,8 +43,15 @@ public abstract class MenuItemBase(MenuItemSettings settings) : IMenuItem
 
     private MenuItem DoGetMenuItem()
     {
-        var subMenuItems = GetSubMenuItems().CreateMenuItems();
+        // Create the header and remove the accelerator key if needed
         var header = settings.Header ?? Header;
+        if (MenuSettings.Instance.HideSubMenuAcceleratorKeys && this is ISubMenuItem)
+            header = header.Replace("_", string.Empty);
+
+        // Get the sub menu items
+        var subMenuItems = GetSubMenuItems().CreateMenuItems();
+
+        // Create the menu item
         var menuItem = new MenuItem
         {
             Header       = header,

--- a/TJC.GUI/Menu/Items/File/ExitCommand.cs
+++ b/TJC.GUI/Menu/Items/File/ExitCommand.cs
@@ -10,6 +10,8 @@ internal class ExitCommand : MenuItemBase, ISubMenuItem
 
     public override string Header => "E_xit";
 
+    public override KeyGesture DefaultGesture => new(Key.F4, KeyModifiers.Alt);
+
     protected override void Execute()
     {
         Environment.Exit(0);

--- a/TJC.GUI/Menu/Items/Help/Help/HelpItem.cs
+++ b/TJC.GUI/Menu/Items/Help/Help/HelpItem.cs
@@ -20,6 +20,8 @@ internal class HelpItem : MenuItemBase, ISubMenuItem
 
     public override string Header => "H_elp";
 
+    public override KeyGesture DefaultGesture => new(Key.F1);
+
     protected override void Execute()
     {
         var popup = new HelpPopup(title: _title,

--- a/TJC.GUI/Menu/Settings/MenuSettings.cs
+++ b/TJC.GUI/Menu/Settings/MenuSettings.cs
@@ -18,6 +18,12 @@ public class MenuSettings : SingletonBase<MenuSettings>
 
     internal Assembly? Assembly { get; set; }
 
+    /// <summary>
+    /// This is defaulted to true since Avalonia currently has a bug with sub-menu accelerator keys.
+    /// https://github.com/AvaloniaUI/Avalonia/issues/7090
+    /// </summary>
+    public Inclusion.Inclusion HideSubMenuAcceleratorKeys { get; } = new();
+
     #region Items
 
     #region File

--- a/TJC.GUI/Menu/Settings/MenuSettings.cs
+++ b/TJC.GUI/Menu/Settings/MenuSettings.cs
@@ -30,7 +30,7 @@ public class MenuSettings : SingletonBase<MenuSettings>
 
     public MenuItemSettings About { get; } = new(true);
 
-    public MenuItemSettings Help { get; } = new(false, gesture: new KeyGesture(Key.F1));
+    public MenuItemSettings Help { get; } = new(false);
 
     public string HelpContent { get; set; } = string.Empty;
 


### PR DESCRIPTION
- Improve the input gestures for menu items so that they are no longer just part of the header, but instead actually set to the input gesture.
- Remove the accelerator keys for sub-menu items, since these don't currently work within Avalonia ([Issue #7090](https://github.com/AvaloniaUI/Avalonia/issues/7090)).
- Set default gestures for **Help (F1)** & **Exit (Alt-F4)**.