### PR TITLE
🐛 fix: Opening Help/About menu twice would crash to program

### DIFF
--- a/TJC.GUI/Menu/Items/Help/About/AboutPopup.axaml.cs
+++ b/TJC.GUI/Menu/Items/Help/About/AboutPopup.axaml.cs
@@ -31,7 +31,7 @@ public partial class AboutPopup : Window
 
         // Changelog
         ChangelogBlock.Markdown = changelog;
-        ChangelogBlock.MarkdownStyle = MenuSettings.Instance.AboutSettings.ChangelogSettings.Style;
+        ChangelogBlock.MarkdownStyle ??= MenuSettings.Instance.AboutSettings.ChangelogSettings.Style;
         ChangelogSection.IsVisible = !string.IsNullOrEmpty(changelog);
 
         // Licenses
@@ -40,7 +40,7 @@ public partial class AboutPopup : Window
             combinedLicenses += TextSeparator;
         combinedLicenses += thirdPartyLicenses;
         LicenseBlock.Markdown = combinedLicenses;
-        LicenseBlock.MarkdownStyle = MenuSettings.Instance.AboutSettings.LicenseSettings.Style;
+        LicenseBlock.MarkdownStyle ??= MenuSettings.Instance.AboutSettings.LicenseSettings.Style;
         LicenseSection.IsVisible = !string.IsNullOrEmpty(combinedLicenses);
     }
 

--- a/TJC.GUI/Menu/Items/Help/Help/HelpPopup.axaml.cs
+++ b/TJC.GUI/Menu/Items/Help/Help/HelpPopup.axaml.cs
@@ -16,7 +16,7 @@ namespace TJC.GUI.Menu.Items.Help.Help
             SetSize();
 
             HelpBlock.Markdown = content;
-            HelpBlock.MarkdownStyle = MenuSettings.Instance.HelpSettings.Style;
+            HelpBlock.MarkdownStyle ??= MenuSettings.Instance.HelpSettings.Style;
         }
 
         private void SetSize()


### PR DESCRIPTION
Since the MarkdownStyle was being set twice